### PR TITLE
fix: move entrypoints to inside /src, fix require paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cpr",
   "version": "0.1.0-dev",
   "description": "A discord bot for our HeartStopper server",
-  "main": "index.js",
+  "main": "src/index.js",
   "private": "true",
   "license": "MIT",
   "engines": {
@@ -10,10 +10,10 @@
     "yarn": ">=1.22.15"
   },
   "scripts": {
-    "start": "node ./index.js",
-    "dev": "nodemon ./index.js",
-    "commands": "node ./deploy-commands.js",
-    "commands-guild": "node ./deploy-commands-guild.js"
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "commands": "node src/deploy-commands.js",
+    "commands-guild": "node src/deploy-commands-guild.js"
   },
   "author": {
     "name": "mkevenaar"

--- a/src/deploy-commands-guild.js
+++ b/src/deploy-commands-guild.js
@@ -18,7 +18,7 @@ async function init_commands() {
 			.filter((file) => file.endsWith('.js'));
 
 		for (const file of commandFiles) {
-			const command = require(`./src/commands/${direct}/${file}`);
+			const command = require(`./commands/${direct}/${file}`);
 			commands.push(command.data.toJSON());
 		}
 	});

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -18,7 +18,7 @@ async function init_commands() {
 			.filter((file) => file.endsWith('.js'));
 
 		for (const file of commandFiles) {
-			const command = require(`./src/commands/${direct}/${file}`);
+			const command = require(`./commands/${direct}/${file}`);
 			commands.push(command.data.toJSON());
 		}
 	});

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,8 @@ const client = new Client({
 	],
 });
 client.commands = new Collection();
-client.database = require('./src/database/mongoose.js');
-client.tools = require('./src/tools/tools.js');
+client.database = require('./database/mongoose.js');
+client.tools = require('./tools/tools.js');
 
 async function init() {
 	// Commands Setup
@@ -31,7 +31,7 @@ async function init() {
 			.filter((file) => file.endsWith('.js'));
 
 		for (const file of commandFiles) {
-			const command = require(`./src/commands/${direct}/${file}`);
+			const command = require(`./commands/${direct}/${file}`);
 			client.commands.set(command.data.name, command);
 		}
 	});
@@ -59,7 +59,7 @@ async function init() {
 	const eventFiles = fs.readdirSync('./src/events').filter((file) => file.endsWith('.js'));
 
 	for (const file of eventFiles) {
-		const event = require(`./src/events/${file}`);
+		const event = require(`./events/${file}`);
 		if (event.once) {
 			client.once(event.name, (...args) => event.execute(...args, client));
 		} else {


### PR DESCRIPTION
## Description

Moves the three entrypoint files into /src whilst fixing the require paths inside to match.

## Related Issue

#15 

## Motivation and Context

This will make it a bit easier to find the entrypoint files - instead of cluttering the root.

## How Has This Been Tested?

With the dev command only

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
